### PR TITLE
시간 계산에서 8진수 해석 오류 수정

### DIFF
--- a/claude-o-clock.sh
+++ b/claude-o-clock.sh
@@ -5,7 +5,7 @@
 
 while true; do
     # Get current hour for context
-    hour=$(date +%H)
+    hour=$((10#$(date +%H)))
     
     # Prepare motivational prompt based on time of day
     if [ $hour -ge 5 ] && [ $hour -lt 12 ]; then
@@ -36,10 +36,10 @@ while true; do
     current_second=$(date +%S)
     
     # Calculate seconds since midnight
-    current_total_seconds=$((current_hour * 3600 + current_minute * 60 + current_second))
+    current_total_seconds=$((10#$current_hour * 3600 + 10#$current_minute * 60 + 10#$current_second))
     
     # Calculate next target time (next hour at 01 minute)
-    next_hour=$(((current_hour + 1) % 24))
+    next_hour=$(((10#$current_hour + 1) % 24))
     target_total_seconds=$((next_hour * 3600 + 60))  # 60 seconds = 1 minute past the hour
     
     # If target is in the next day (past midnight)


### PR DESCRIPTION
08시나 09시에 스크립트 실행 시 "08: value too great for base (error token is "08")" 오류가 발생했습니다.
이는 bash가 산술 연산에서 앞에 0이 붙은 숫자를 8진수로 해석하는데, 8진수에는 8과 9가 존재하지 않기 때문입니다.
수정 내용은 아래와 같습니다.

- 시간 계산에서 10진수 해석을 강제하는 10# 접두사 추가
- 36번째 줄 current_total_seconds 계산 수정
- 39번째 줄 next_hour 계산 수정
- 8번째 줄 hour 변수 할당 수정

with Claude Code